### PR TITLE
Support :lineno as a line number fragment.

### DIFF
--- a/plugin/utl_uri.vim
+++ b/plugin/utl_uri.vim
@@ -247,7 +247,12 @@ endfu
 fu! UriRef_getUri(uriref)
     let idx = match(a:uriref, '#')
     if idx==-1
-	return a:uriref
+        " check for special case :digits
+        let idx2 = match(a:uriref, ':[0-9]\+$')
+        if idx2==-1
+            return a:uriref
+        endif
+        return strpart(a:uriref, 0, idx2)
     endif
     return strpart(a:uriref, 0, idx)
 endfu
@@ -259,7 +264,12 @@ endfu
 fu! UriRef_getFragment(uriref)
     let idx = match(a:uriref, '#')
     if idx==-1
-	return '<undef>'
+        " check for special case :digits and translate to line=digits
+        let idx2 = match(a:uriref, ':[0-9]\+$')
+        if idx2==-1
+            return '<undef>'
+        endif
+        return "line=" . strpart(a:uriref, idx2+1, 9999)
     endif
     return strpart(a:uriref, idx+1, 9999)
 endfu


### PR DESCRIPTION
This change allows the common :lineno format to be used to specify a
line number to jump to inside a file. To make the change as small as
possible the format is translated to match the existing line number
fragment specifier line=lineno.

The fragment will only match if the end of the URI is a colon and digits
until the end of the string. This would be a rare case in a most URIs.